### PR TITLE
Fix: ImmutablePoint<> needs equality operator. #1

### DIFF
--- a/Math.UnitTests/ImmutablePointUT.cs
+++ b/Math.UnitTests/ImmutablePointUT.cs
@@ -6,7 +6,7 @@ namespace SharperHacks.CoreLibs.Math.UnitTests;
 
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class PointUT
+public class ImmutablePointUT
 {
     [TestMethod]
     public void SmokeIt()
@@ -26,6 +26,23 @@ public class PointUT
         Assert.AreEqual(1, p3.Coordinates[0]);
 
         Assert.AreEqual(2, p2.Coordinates[1]);
+    }
+
+    [TestMethod]
+    public void EqualityTests()
+    {
+        var p1 = new ImmutablePoint<int>(100, 100);
+        var p2 = p1;
+        var p3 = new ImmutablePoint<int>(100, 100);
+
+        Console.WriteLine($"{p1}, {p1.ToString(true)}");
+        Console.WriteLine($"{p2}, {p2.ToString(true)}");
+        Console.WriteLine($"{p3}, {p3.ToString(true)}");
+
+        Assert.AreEqual(p1, p2);
+        Assert.AreEqual(p1, p3);
+        Assert.AreEqual(p2, p3);
+        Assert.AreEqual(p3, p3);
     }
 }
 

--- a/Math/ImmutablePointT.cs
+++ b/Math/ImmutablePointT.cs
@@ -12,18 +12,24 @@ namespace SharperHacks.CoreLibs.Math;
 /// <summary>
 /// An immutable implementation of IPoint.
 /// </summary>
+/// <remarks>
+/// Includes value semantics for equality and hash code. No attempt will be
+/// made to provide other comparison operators, as that should be done at
+/// the appropriate domain specific container level. Addition, subtraction,
+/// multiplication and division operators should be included in derived types.
+/// </remarks>
 public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
 {
     #region IPoint{T}
 
     /// <inheritdoc cref="IPoint{T}.Dimensions"/>
-    public int Dimensions { get; init; }
+    public int Dimensions => Coordinates.Count;
 
     /// <inheritdoc cref="IPoint{T}.Coordinates"/>
     public ImmutableList<T> Coordinates { get; init; }
 
     #endregion IPoint{T}
-
+    
     #region Constructors
     /// <summary>
     /// constructor taking coordinate value array.
@@ -34,7 +40,6 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
         Verify.IsNotNull(coordinates);
         Verify.IsGreaterThan(coordinates.Length, 0, "Coordinate values must not be empty.");
 
-        Dimensions = coordinates.Length;
         Coordinates = ImmutableList.Create(coordinates);
     }
 
@@ -45,7 +50,6 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
     /// <param name="y"></param>
     public ImmutablePoint(T x, T y)
     {
-        Dimensions = 2;
         Coordinates = ImmutableList.Create(x, y);
     }
 
@@ -57,10 +61,32 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
     /// <param name="z"></param>
     public ImmutablePoint(T x, T y, T z)
     {
-        Dimensions = 3;
         Coordinates = ImmutableList.Create(x, y, z);
     }
     #endregion Constructors
+
+    #region Object Overrides and special methods
+
+    /// <inheritdoc/>
+    public bool Equals(ImmutablePoint<T> other) =>
+        other.Dimensions == Dimensions && Coordinates.SequenceEqual(other.Coordinates);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+
+        hash.Add(Dimensions);
+
+        foreach (var component in Coordinates)
+        {
+            hash.Add(component);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    #endregion Object Overrides and special methods
 
     /// <inheritdoc cref="object.ToString"/>
     public override string ToString() => ToString(false);


### PR DESCRIPTION
Equals now applies value semantics to the coordinate array and the GetHashCode() method has been overridden accordingly.

  renamed:    Math.UnitTests/PointUT.cs -> Math.UnitTests/ImmutablePointUT.cs
  modified:   Math/ImmutablePointT.cs