### PR TITLE
Derive a ImmutableCartesianPoint<T> from ImmutablePoint<T> #2

### DIFF
--- a/Math.Interfaces/IPointT.cs
+++ b/Math.Interfaces/IPointT.cs
@@ -17,12 +17,19 @@ public interface IPoint<T> where T : INumber<T>
     /// <remarks>
     /// Must be a non-zero positive value.
     /// </remarks>
-    public int Dimensions { get; }
+    int Dimensions { get; }
 
     /// <summary>
     /// Get a list of points on each axis.
     /// </summary>
-    public ImmutableList<T> Coordinates { get; }
+    ImmutableList<T> Coordinates { get; }
+
+    /// <summary>
+    /// Get the component at the specified index.
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns>The component value at that index.</returns>
+    T this[int index] => Coordinates[index];
 }
 
 // Copyright Joseph W Donahue and Sharper Hacks LLC (US-WA)

--- a/Math.UnitTests/IPointUT.cs
+++ b/Math.UnitTests/IPointUT.cs
@@ -1,0 +1,41 @@
+// Copyright and trademark notices at bottom of file.
+
+using SharperHacks.CoreLibs.Math.Interfaces;
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace SharperHacks.CoreLibs.Math.UT;
+
+[ExcludeFromCodeCoverage]
+[TestClass]
+public class IPointUT
+{
+    [TestMethod]
+    public void CoverDefaultImplementationPaths()
+    {
+        IPoint<int> p1 = new ImmutablePoint<int>(0, 1, 2, 3, 4, 5);
+
+        for(var idx = 0; idx < p1.Dimensions; idx++)
+        {
+            Assert.AreEqual(idx, p1[idx]);
+        }
+    }
+}
+
+// Copyright Joseph W Donahue and Sharper Hacks LLC (US-WA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SharperHacks is a trademark of Sharper Hacks LLC (US-Wa), and may not be
+// applied to distributions of derivative works, without the express written
+// permission of a registered officer of Sharper Hacks LLC (US-WA).

--- a/Math.UnitTests/ImmutableCartesianPointUT.cs
+++ b/Math.UnitTests/ImmutableCartesianPointUT.cs
@@ -1,0 +1,131 @@
+// Copyright and trademark notices at bottom of file.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace SharperHacks.CoreLibs.Math.UT;
+
+[ExcludeFromCodeCoverage]
+[TestClass]
+public class ImmutableCartesianPointUT
+{
+    [TestMethod]
+    public void SmokeIt()
+    {
+        var p1 = new ImmutableCartesianPoint<int>(1);
+        var p2 = new ImmutableCartesianPoint<int>(1, 2);
+        var p3 = new ImmutableCartesianPoint<int>(1, 2, 3);
+
+        Console.WriteLine(p1);
+        Console.WriteLine(p2);
+        Console.WriteLine(p3);
+
+        Console.WriteLine(p3.ToString(true));
+
+        Assert.AreEqual(1, p1.Coordinates[0]);
+        Assert.AreEqual(1, p2.Coordinates[0]);
+        Assert.AreEqual(1, p3.Coordinates[0]);
+
+        Assert.AreEqual(2, p2.Coordinates[1]);
+    }
+
+    [TestMethod]
+    public void GetHashCodeTest()
+    {
+        var origin1 = new ImmutableCartesianPoint<double>(0.0, 0.0, 0.0);
+        var origin2 = new ImmutableCartesianPoint<double>(0.0, 0.0, 0.0);
+        var origin3 = new ImmutableCartesianPoint<float>(0, 0, 0);
+        var p1 = origin1;
+        var p2 = new ImmutableCartesianPoint<double>(0.0, 0.0, 0.0);
+
+        Console.WriteLine($"origin1 == {origin1}");
+        Console.WriteLine($"origin2 == {origin2}");
+        Console.WriteLine($"origin3 == {origin3}");
+        Console.WriteLine($"p1 == {p1}");
+        Console.WriteLine($"p2 == {p2}");
+
+        Assert.AreEqual(origin1.GetHashCode(), p1.GetHashCode());
+        Assert.AreEqual(origin1.GetHashCode(), origin2.GetHashCode());
+        Assert.AreEqual(origin1.GetHashCode(), origin3.GetHashCode());
+        Assert.AreEqual(origin1.GetHashCode(), p1.GetHashCode());
+        Assert.AreEqual(p1.GetHashCode(), p2.GetHashCode());
+    }
+
+    [TestMethod]
+    public void MultiplicationAndDivisionTest()
+    {
+        var p1 = new ImmutableCartesianPoint<int>(2, 2, 2);
+        var scaledUp = p1 * 3;
+        var scaledDown = scaledUp / 3;
+        var expectedUp = new ImmutableCartesianPoint<int>(6, 6, 6);
+        var expectedDown = new ImmutableCartesianPoint<int>(2, 2, 2);
+
+        Console.WriteLine(p1);
+        Console.WriteLine(scaledUp);
+
+        Assert.AreEqual(expectedUp, scaledUp);
+        Assert.AreEqual(expectedDown, scaledDown);
+    }
+
+    [TestMethod]
+    public void MinusOperatorTests()
+    {
+        var p1 = new ImmutableCartesianPoint<int>(0, 0, 0);
+        var offset1 = new ImmutableCartesianPoint<int>(2, 2, 0);
+
+        var p2 = p1 - offset1;
+
+        Console.WriteLine(p1);
+        Console.WriteLine(p2);
+
+        Assert.AreEqual(3, p2.Dimensions);
+
+        Assert.AreEqual(-2, p2.Coordinates[0]);
+        Assert.AreEqual(-2, p2.Coordinates[1]);
+        Assert.AreEqual(0, p2.Coordinates[2]);
+    }
+
+    [TestMethod]
+    public void PlusOperatorTests()
+    {
+        var p1 = new ImmutableCartesianPoint<int>(0, 0, 0);
+        var offset1 = new ImmutableCartesianPoint<int>(2, 2, 0);
+
+        var p2 = p1 + offset1;
+
+        Console.WriteLine(p1);
+        Console.WriteLine(p2);
+
+        Assert.AreEqual(3, p2.Dimensions);
+
+        Assert.AreEqual(2, p2.Coordinates[0]);
+        Assert.AreEqual(2, p2.Coordinates[1]);
+        Assert.AreEqual(0, p2.Coordinates[2]);
+    }
+
+    [TestMethod]
+    public void ToStringTest()
+    {
+        var p1 = new ImmutableCartesianPoint<byte>(0, 0, 0);
+
+        Console.WriteLine(p1.ToString());
+        Console.WriteLine(p1.ToString(true));
+    }
+}
+
+// Copyright Joseph W Donahue and Sharper Hacks LLC (US-WA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SharperHacks is a trademark of Sharper Hacks LLC (US-Wa), and may not be
+// applied to distributions of derivative works, without the express written
+// permission of a registered officer of Sharper Hacks LLC (US-WA).

--- a/Math.UnitTests/ImmutablePointUT.cs
+++ b/Math.UnitTests/ImmutablePointUT.cs
@@ -6,7 +6,7 @@ namespace SharperHacks.CoreLibs.Math.UnitTests;
 
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class PointUT
+public class ImmutablePointUT
 {
     [TestMethod]
     public void SmokeIt()
@@ -26,6 +26,23 @@ public class PointUT
         Assert.AreEqual(1, p3.Coordinates[0]);
 
         Assert.AreEqual(2, p2.Coordinates[1]);
+    }
+
+    [TestMethod]
+    public void EqualityTests()
+    {
+        var p1 = new ImmutablePoint<int>(100, 100);
+        var p2 = p1;
+        var p3 = new ImmutablePoint<int>(100, 100);
+
+        Console.WriteLine($"{p1}, {p1.ToString(true)}");
+        Console.WriteLine($"{p2}, {p2.ToString(true)}");
+        Console.WriteLine($"{p3}, {p3.ToString(true)}");
+
+        Assert.AreEqual(p1, p2);
+        Assert.AreEqual(p1, p3);
+        Assert.AreEqual(p2, p3);
+        Assert.AreEqual(p3, p3);
     }
 }
 

--- a/Math.UnitTests/ImmutablePointUT.cs
+++ b/Math.UnitTests/ImmutablePointUT.cs
@@ -2,10 +2,10 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace SharperHacks.CoreLibs.Math.UnitTests;
+namespace SharperHacks.CoreLibs.Math.UT;
 
-[TestClass]
 [ExcludeFromCodeCoverage]
+[TestClass]
 public class ImmutablePointUT
 {
     [TestMethod]
@@ -43,6 +43,19 @@ public class ImmutablePointUT
         Assert.AreEqual(p1, p3);
         Assert.AreEqual(p2, p3);
         Assert.AreEqual(p3, p3);
+    }
+
+    [TestMethod]
+    public void CoverGetHashCode()
+    {
+        var p1 = new ImmutablePoint<int>(0, 0);
+        var p2 = p1;
+        var p3 = new ImmutablePoint<float>(0f, 0f);
+        var p4 = new ImmutablePoint<float>(0.5f, 0.5f);
+
+        Assert.AreEqual(p1.GetHashCode(), p2.GetHashCode());
+        Assert.AreEqual(p2.GetHashCode(), p3.GetHashCode()); 
+        Assert.AreNotEqual(p3.GetHashCode(), p4.GetHashCode());
     }
 }
 

--- a/Math.UnitTests/IntervalTSmokeTests.cs
+++ b/Math.UnitTests/IntervalTSmokeTests.cs
@@ -5,7 +5,7 @@ using SharperHacks.CoreLibs.Math.Interfaces;
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace SharperHacks.CoreLibs.Math.UnitTests;
+namespace SharperHacks.CoreLibs.Math.UT;
 
 [ExcludeFromCodeCoverage]
 [TestClass]

--- a/Math.UnitTests/Math.UnitTests.csproj
+++ b/Math.UnitTests/Math.UnitTests.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Math.UnitTests/PolygonUT.cs
+++ b/Math.UnitTests/PolygonUT.cs
@@ -1,7 +1,10 @@
 // Copyright and trademark notices at bottom of file.
 
-namespace SharperHacks.CoreLibs.Math.UnitTests;
+using System.Diagnostics.CodeAnalysis;
 
+namespace SharperHacks.CoreLibs.Math.UT;
+
+[ExcludeFromCodeCoverage]
 [TestClass]
 public class PolygonUT
 {
@@ -40,7 +43,7 @@ public class PolygonUT
         Console.WriteLine($"ToString(false) == {diagnosticDisabled}");
         Console.WriteLine($"ToString() == {normalForm}");
 
-        Assert.AreEqual(expectedEnabled, diagnosticEnabled );
+        Assert.AreEqual(expectedEnabled, diagnosticEnabled);
         Assert.AreEqual(expectedDisabled, diagnosticDisabled );
         Assert.AreEqual(expectedNormal, normalForm );
     }

--- a/Math.UnitTests/StatsSmokeTests.cs
+++ b/Math.UnitTests/StatsSmokeTests.cs
@@ -2,7 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace SharperHacks.CoreLibs.Math.UnitTests;
+namespace SharperHacks.CoreLibs.Math.UT;
 
 [ExcludeFromCodeCoverage]
 [TestClass]

--- a/Math/ImmutableCartesianPointT.cs
+++ b/Math/ImmutableCartesianPointT.cs
@@ -1,0 +1,228 @@
+// Copyright and trademark notices at bottom of file.
+
+
+using SharperHacks.CoreLibs.Constraints;
+using SharperHacks.CoreLibs.Math.Interfaces;
+
+using System.Collections.Immutable;
+using System.Numerics;
+
+namespace SharperHacks.CoreLibs.Math;
+
+/// <summary>
+/// Implements IPoint{T} with minimal cartesian coordinate operators.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public readonly record struct ImmutableCartesianPoint<T>
+    : IPoint<T> where T : INumber<T>
+{
+    private readonly ImmutablePoint<T> _point;
+
+    #region IPoint{T}
+
+    /// <inheritdoc cref="IPoint{T}.Dimensions"/>
+    public int Dimensions => _point.Dimensions;
+
+    /// <inheritdoc cref="IPoint{T}.Coordinates"/>
+    public ImmutableList<T> Coordinates => _point.Coordinates;
+
+    #endregion IPoint{T}
+
+    #region Constructors
+
+    /// <summary>
+    /// constructor taking coordinate value array.
+    /// </summary>
+    /// <param name="coordinates"></param>
+    public ImmutableCartesianPoint(params T[] coordinates)
+    {
+        Verify.IsNotNull(coordinates);
+        Verify.IsGreaterThan(coordinates.Length, 0, "Coordinate values must not be empty.");
+
+        _point = new ImmutablePoint<T>(coordinates);
+    }
+
+    /// <summary>
+    /// Constructor for standard 2D geometry.
+    /// </summary>
+    /// <param name="x"></param>
+    /// <param name="y"></param>
+    public ImmutableCartesianPoint(T x, T y) => 
+        _point = new ImmutablePoint<T>(x, y);
+
+    /// <summary>
+    /// Constructor for standard 3D geometry.
+    /// </summary>
+    /// <param name="x"></param>
+    /// <param name="y"></param>
+    /// <param name="z"></param>
+    public ImmutableCartesianPoint(T x, T y, T z) =>
+        _point = new ImmutablePoint<T>(x, y,z);
+
+    /// <summary>
+    /// Constructor taking List{T}
+    /// </summary>
+    /// <param name="coordinates"></param>
+    public ImmutableCartesianPoint(List<T> coordinates)
+    {
+        Verify.IsNotNull(coordinates);
+        Verify.IsGreaterThan(coordinates.Count, 0, "Coordinate values must not be empty.");
+
+        _point = new ImmutablePoint<T>(coordinates);
+    }
+
+    #endregion Constructors
+
+    #region Object Overrides and special methods
+
+    /// <inheritdoc/>
+    public bool Equals(ImmutableCartesianPoint<T> other) =>
+        _point.Equals(other._point);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => _point.GetHashCode();
+
+    /// <inheritdoc cref="object.ToString"/>
+    public override string ToString() => _point.ToString();
+
+    /// <inheritdoc cref="ImmutablePoint{T}.ToString(bool)"/>
+    public string ToString(bool diagnostic) => _point.ToString(diagnostic);
+
+    #endregion Object Overrides and special methods
+
+    #region Operators
+
+    /// <summary>
+    /// Get component at the specified index.
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns></returns>
+    public T this[int index] => Coordinates[index];
+
+    /// <summary>
+    /// Sum two IPoint{T}'s.
+    /// </summary>
+    /// <param name="left"></param>
+    /// <param name="right"></param>
+    /// <returns></returns>
+    public static ImmutableCartesianPoint<T> 
+        operator +(ImmutableCartesianPoint<T> left, IPoint<T> right) 
+        => Sum(left, right);
+
+    /// <summary>
+    /// Subtract right operand from left.
+    /// </summary>
+    /// <param name="left"></param>
+    /// <param name="right"></param>
+    /// <returns></returns>
+    public static ImmutableCartesianPoint<T>
+        operator -(ImmutableCartesianPoint<T> left, IPoint<T> right)
+        => Diff(left, right);
+
+    /// <summary>
+    /// Multiply the point by the scale factor.
+    /// </summary>
+    /// <param name="p"></param>
+    /// <param name="scaleFactor"></param>
+    /// <returns>
+    /// New ImmutableCartesionPoint{T}.
+    /// </returns>
+    public static ImmutableCartesianPoint<T>
+        operator *(ImmutableCartesianPoint<T> p, T scaleFactor)
+    {
+        var results = new List<T>();
+
+        foreach (var component in p.Coordinates)
+        {
+            checked
+            {
+                results.Add(component * scaleFactor);
+            }
+        }
+
+        return new ImmutableCartesianPoint<T>(results);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="p"></param>
+    /// <param name="scaleFactor"></param>
+    /// <returns></returns>
+    public static ImmutableCartesianPoint<T> 
+        operator /(ImmutableCartesianPoint<T> p, T scaleFactor)
+    {
+        var results = new List<T>();
+
+        foreach(var component in p.Coordinates)
+        {
+            checked
+            {
+                results.Add(component / scaleFactor);
+            }
+        }
+
+        return new ImmutableCartesianPoint<T>(results);
+    }
+
+    private static ImmutableCartesianPoint<T> Sum(ImmutableCartesianPoint<T> left, IPoint<T> right)
+    {
+        Verify.IsNotNull(left);
+        Verify.IsNotNull(right);
+        Verify.AreEqual(left.Dimensions, right.Dimensions,
+            "Left and right operands, must have same number of dimensions.");
+
+        var results = new List<T>();
+
+        for (var idx = 0; idx < left.Dimensions; idx++)
+        {
+            checked
+            {
+                results.Add(left[idx] + right[idx]);
+            }
+        }
+
+        return new(results);
+    }
+
+    private static ImmutableCartesianPoint<T> Diff(ImmutableCartesianPoint<T> left, IPoint<T> right)
+    {
+        Verify.IsNotNull(left);
+        Verify.IsNotNull(right);
+        Verify.AreEqual(left.Dimensions, right.Dimensions,
+            "Left and right operands, must have same number of dimensions.");
+
+        var results = new List<T>();
+
+        for (var idx = 0; idx < left.Dimensions; idx++)
+        {
+            checked
+            {
+                results.Add(left[idx] - right[idx]);
+            }
+        }
+
+        return new(results);
+    }
+
+
+    #endregion Operators
+}
+
+// Copyright Joseph W Donahue and Sharper Hacks LLC (US-WA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SharperHacks is a trademark of Sharper Hacks LLC (US-Wa), and may not be
+// applied to distributions of derivative works, without the express written
+// permission of a registered officer of Sharper Hacks LLC (US-WA).

--- a/Math/ImmutablePointT.cs
+++ b/Math/ImmutablePointT.cs
@@ -12,18 +12,24 @@ namespace SharperHacks.CoreLibs.Math;
 /// <summary>
 /// An immutable implementation of IPoint.
 /// </summary>
+/// <remarks>
+/// Includes value semantics for equality and hash code. No attempt will be
+/// made to provide other comparison operators, as that should be done at
+/// the appropriate domain specific container level. Addition, subtraction,
+/// multiplication and division operators should be included in derived types.
+/// </remarks>
 public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
 {
     #region IPoint{T}
 
     /// <inheritdoc cref="IPoint{T}.Dimensions"/>
-    public int Dimensions { get; init; }
+    public int Dimensions => Coordinates.Count;
 
     /// <inheritdoc cref="IPoint{T}.Coordinates"/>
     public ImmutableList<T> Coordinates { get; init; }
 
     #endregion IPoint{T}
-
+    
     #region Constructors
     /// <summary>
     /// constructor taking coordinate value array.
@@ -34,7 +40,6 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
         Verify.IsNotNull(coordinates);
         Verify.IsGreaterThan(coordinates.Length, 0, "Coordinate values must not be empty.");
 
-        Dimensions = coordinates.Length;
         Coordinates = ImmutableList.Create(coordinates);
     }
 
@@ -45,7 +50,6 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
     /// <param name="y"></param>
     public ImmutablePoint(T x, T y)
     {
-        Dimensions = 2;
         Coordinates = ImmutableList.Create(x, y);
     }
 
@@ -57,10 +61,32 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
     /// <param name="z"></param>
     public ImmutablePoint(T x, T y, T z)
     {
-        Dimensions = 3;
         Coordinates = ImmutableList.Create(x, y, z);
     }
     #endregion Constructors
+
+    #region Object Overrides and special methods
+
+    /// <inheritdoc/>
+    public bool Equals(ImmutablePoint<T> other) =>
+        other.Dimensions == Dimensions && Coordinates.SequenceEqual(other.Coordinates);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+
+        hash.Add(Dimensions);
+
+        foreach (var component in Coordinates)
+        {
+            hash.Add(component);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    #endregion Object Overrides and special methods
 
     /// <inheritdoc cref="object.ToString"/>
     public override string ToString() => ToString(false);

--- a/Math/ImmutablePointT.cs
+++ b/Math/ImmutablePointT.cs
@@ -31,6 +31,7 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
     #endregion IPoint{T}
     
     #region Constructors
+
     /// <summary>
     /// constructor taking coordinate value array.
     /// </summary>
@@ -48,10 +49,7 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
     /// </summary>
     /// <param name="x"></param>
     /// <param name="y"></param>
-    public ImmutablePoint(T x, T y)
-    {
-        Coordinates = ImmutableList.Create(x, y);
-    }
+    public ImmutablePoint(T x, T y) => Coordinates = [x, y];
 
     /// <summary>
     /// Constructor for standard 3D geometry.
@@ -59,10 +57,14 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
     /// <param name="x"></param>
     /// <param name="y"></param>
     /// <param name="z"></param>
-    public ImmutablePoint(T x, T y, T z)
-    {
-        Coordinates = ImmutableList.Create(x, y, z);
-    }
+    public ImmutablePoint(T x, T y, T z) => Coordinates = [x, y, z];
+
+    /// <summary>
+    /// Constructor taking coordinate value list.
+    /// </summary>
+    /// <param name="coordinates"></param>
+    public ImmutablePoint(List<T> coordinates) => Coordinates = coordinates.ToImmutableList();
+
     #endregion Constructors
 
     #region Object Overrides and special methods
@@ -85,8 +87,6 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
 
         return hash.ToHashCode();
     }
-
-    #endregion Object Overrides and special methods
 
     /// <inheritdoc cref="object.ToString"/>
     public override string ToString() => ToString(false);
@@ -123,6 +123,8 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
 
         return sb.ToString();
     }
+
+    #endregion Object Overrides and special methods
 }
 
 // Copyright Joseph W Donahue and Sharper Hacks LLC (US-WA)

--- a/Math/ImmutablePointT.cs
+++ b/Math/ImmutablePointT.cs
@@ -102,7 +102,7 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
 
         if (diagnostic)
         {
-            sb.Append("ImmutablePoint { Dimensions = ")
+            sb.Append($"{nameof(ImmutablePoint<T>)} {{ Dimensions = ")
               .Append(Dimensions)
               .Append(", Coordinates = ");
         }
@@ -124,7 +124,7 @@ public readonly record struct ImmutablePoint<T> : IPoint<T> where T: INumber<T>
         return sb.ToString();
     }
 
-    #endregion Object Overrides and special methods
+#endregion Object Overrides and special methods
 }
 
 // Copyright Joseph W Donahue and Sharper Hacks LLC (US-WA)

--- a/Math/ImmutablePolygonT.cs
+++ b/Math/ImmutablePolygonT.cs
@@ -54,7 +54,7 @@ public class ImmutablePolygon<T> : IPolygon<T> where T : INumber<T>
         var downCounter = VertexCount;
         foreach(var item in Vertices)
         {
-            sb.Append(item);
+            sb.Append(item.ToString()); // JwD: We don't need diagnostics here.
             downCounter--;
             if (downCounter > 0) sb.Append(',');
         }


### PR DESCRIPTION
    Feat: Derive a ImmutableCartesianPoint<T> from ImmutablePoint<T> #2

      new file:   Math.UnitTests/IPointUT.cs
      new file:   Math.UnitTests/ImmutableCartesianPointUT.cs
      modified:   Math.UnitTests/ImmutablePointUT.cs
      modified:   Math.UnitTests/IntervalTSmokeTests.cs
      modified:   Math.UnitTests/Math.UnitTests.csproj
      modified:   Math.UnitTests/PolygonUT.cs
      modified:   Math.UnitTests/StatsSmokeTests.cs
      new file:   Math/ImmutableCartesianPointT.cs
      modified:   Math/ImmutablePointT.cs
      modified:   Math/ImmutablePolygonT.cs
